### PR TITLE
Import framework now accepts relative paths and no longer cycles through directories infinitely.

### DIFF
--- a/src/main/java/org/cinchapi/concourse/importer/FileLineImporter.java
+++ b/src/main/java/org/cinchapi/concourse/importer/FileLineImporter.java
@@ -28,9 +28,12 @@ import java.io.FileReader;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.List;
+
 import javax.annotation.Nullable;
 
 import org.cinchapi.concourse.Concourse;
+import org.cinchapi.concourse.util.FileUtility;
+
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
@@ -104,7 +107,7 @@ public abstract class FileLineImporter extends AbstractImporter {
         List<ImportResult> results = Lists.newArrayList();
         String[] keys = header();
         try {
-            BufferedReader reader = new BufferedReader(new FileReader(file));
+            BufferedReader reader = new BufferedReader(new FileReader(FileUtility.expandPath(file)));
             String line;
             while ((line = reader.readLine()) != null) {
                 if(keys == null) {

--- a/src/main/java/org/cinchapi/concourse/importer/cli/AbstractImportCli.java
+++ b/src/main/java/org/cinchapi/concourse/importer/cli/AbstractImportCli.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.cinchapi.concourse.cli.CommandLineInterface;
 import org.cinchapi.concourse.cli.Options;
+import org.cinchapi.concourse.util.FileUtility;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Stopwatch;
@@ -102,7 +103,7 @@ public abstract class AbstractImportCli extends CommandLineInterface {
         ExecutorService executor = Executors
                 .newFixedThreadPool(((ImportOptions) options).numThreads);
         String data = ((ImportOptions) options).data;
-        List<String> files = scan(Paths.get(data));
+        List<String> files = scan(Paths.get(FileUtility.expandPath(data)));
         Stopwatch watch = Stopwatch.createStarted();
         for (final String file : files) {
             executor.execute(new Runnable() {
@@ -137,7 +138,7 @@ public abstract class AbstractImportCli extends CommandLineInterface {
             if(Files.isDirectory(path)) {
                 Iterator<Path> it = Files.newDirectoryStream(path).iterator();
                 while (it.hasNext()) {
-                    files.addAll(scan(path));
+                    files.addAll(scan(it.next()));
                 }
             }
             else {

--- a/src/main/java/org/cinchapi/concourse/util/FileUtility.java
+++ b/src/main/java/org/cinchapi/concourse/util/FileUtility.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2014 Jeff Nelson, Cinchapi Software Collective
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cinchapi.concourse.util;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
+ 
+/**
+ * Simple Utility providing tools for working with the file system and paths.
+ * 
+ * @author jnelson
+ */
+public class FileUtility {
+ 
+    /**
+     * The user's home directory, which is used to expand path names with "~"
+     * (tilde).
+     */
+    private static String USER_HOME = System.getProperty("user.home");
+ 
+    /**
+     * The working directory from which the current JVM process was launched.
+     */
+    private static String WORKING_DIRECTORY = System.getProperty("user.dir");
+ 
+    /**
+     * The base path that is used to resolve and normalize other relative paths.
+     */
+    private static Path BASE_PATH = FileSystems.getDefault().getPath(
+            WORKING_DIRECTORY);
+ 
+    /**
+     * Expand the given {@code path} so that it contains completely normalized
+     * components (e.g. ".", "..", and "~" are resolved to the correct absolute
+     * paths).
+     * 
+     * @param path
+     * @return the expanded path
+     */
+    public static String expandPath(String path) {
+        path = path.replaceAll("~", USER_HOME);
+        path = path.replaceAll("\\$HOME", USER_HOME);
+        return BASE_PATH.resolve(path).normalize().toString();
+    }
+    
+    /**
+     * Returns the value of {@link USER_HOME} directory.
+     * @return
+     */
+    public static String getUserHome (){
+    	return USER_HOME;
+    }
+    
+    /**
+     * Returns the value of {@link BASE_PATH} directory.
+     * @return
+     */
+    public static Path getBasePath(){
+    	return BASE_PATH;
+    }
+    
+    /**
+     * Returns the value of {@link WORKING_DIRECTORY} directory.
+     * @return
+     */
+    public static String getWorkingDirectory (){
+    	return WORKING_DIRECTORY;
+    }
+    
+}

--- a/src/test/java/org/cinchapi/concourse/importer/cli/GeneralCsvImportCliTest.java
+++ b/src/test/java/org/cinchapi/concourse/importer/cli/GeneralCsvImportCliTest.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2014 Jeff Nelson, Cinchapi Software Collective
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cinchapi.concourse.importer.cli;
+
+import org.cinchapi.concourse.test.ClientServerTest;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link GeneralCsvImportCli}.
+ * @author hmitchell
+ *
+ */
+public class GeneralCsvImportCliTest extends ClientServerTest {
+
+    @Override
+    protected void afterEachTest() {
+    	importCli = null;
+    }
+
+    @Override
+    protected void beforeEachTest() {
+    	importCli = getImportCli();
+    }
+
+    /**
+     * Test that a {@link GeneralCsvImportCli} command line interface can accept 
+     * arguments and import a directory of files without any exceptions.
+     */
+	@Test
+	public void testImportDirectory () throws Exception {
+		importCli.run();
+	}
+	
+	/**
+	 * Return a {@link GeneralCsvImportCli} created with default arguments and {@link pathToData}.
+	 * @return
+	 */
+	public GeneralCsvImportCli getImportCli (){
+		 return new GeneralCsvImportCli("--password", "admin", "-p", String.valueOf(server.getClientPort()), "-d", pathToData());
+	}
+	
+	/**
+	 * Path to data to import for test cases.
+	 * @return
+	 */
+	protected String pathToData(){
+		return "bin/../src/test/resources";
+	}
+
+    @Override
+    protected String getServerVersion() {
+        return "0.3.4";
+    }
+	
+    /**
+     * {@link GeneralCsvImportCli} used for test cases.
+     */
+	protected GeneralCsvImportCli importCli;
+
+}

--- a/src/test/java/org/cinchapi/concourse/util/TestFileUtility.java
+++ b/src/test/java/org/cinchapi/concourse/util/TestFileUtility.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2014 Jeff Nelson, Cinchapi Software Collective
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cinchapi.concourse.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * 
+ * Unit tests for {@link FileUtility}.
+ * @author hmitchell
+ *
+ */
+public class TestFileUtility {
+
+	/**
+	 * Test that relative paths with be resolved correctly.
+	 */
+	@Test 
+    public void testExpandPath() {
+		// Test paths starting with "." and containing ".."
+        String path = "./bin/../src/resources";
+        Assert.assertEquals("correct_path_1", FileUtility.getWorkingDirectory() + "/src/resources", FileUtility.expandPath(path));
+        // Test paths with multiple ".."
+        path = "bin/../bin/../src/resources";
+        Assert.assertEquals("correct_path_2", FileUtility.getWorkingDirectory() + "/src/resources", FileUtility.expandPath(path));
+        // Test Unix home tilde.
+        path = "~";
+        Assert.assertEquals("correct_path_3", FileUtility.getUserHome(), FileUtility.expandPath(path)); 
+        // Test path with multiple consecutive forward slash.
+        path = "./src/resources/////////////////";
+        Assert.assertEquals("correct_path_4", FileUtility.getWorkingDirectory() + "/src/resources", FileUtility.expandPath(path)); 
+        // Test path with multiple consecutive forward slash, followed by multiple "..".        
+        path = "./src/resources/////////////////../..";
+        Assert.assertEquals("correct_path_5", FileUtility.getWorkingDirectory(), FileUtility.expandPath(path));
+        // Test path with $HOME.
+        path = "$HOME";
+        Assert.assertEquals("correct_path_6", FileUtility.getUserHome(), FileUtility.expandPath(path)); 
+    }
+}


### PR DESCRIPTION
* Added FileUtility to expand relative paths.
* AbstractImportCli uses new file utilities to expand paths.
* AbstractImportCli.scan: fixed bug causing infinite loop.
* Added tests for included changes.
* https://cinchapi.atlassian.net/browse/CON-127