### PR TITLE
Concourse-import uses new concourse-cli framework (version 1.1.3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compile ('org.cinchapi:concourse-config:1.0.4'){
     	exclude group: 'org.cinchapi', module:'concourse'
     }
-    compile ('org.cinchapi:concourse-cli:1.1.0'){
+    compile ('org.cinchapi:concourse-cli:1.1.3'){
     	exclude group: 'org.cinchapi', module:'concourse'
     }
     compile 'com.google.guava:guava:15.0'

--- a/src/main/java/org/cinchapi/concourse/importer/FileLineImporter.java
+++ b/src/main/java/org/cinchapi/concourse/importer/FileLineImporter.java
@@ -82,6 +82,15 @@ public abstract class FileLineImporter extends AbstractImporter {
     }
 
     /**
+     * Construct a new instance with a Concourse instance.
+     * 
+     * @param concourse
+     */
+    protected FileLineImporter(Concourse concourse) {
+        super(concourse);
+    }
+
+    /**
      * Import the lines in {@code file}.
      * <p>
      * Each individual line of the file will be possibly split by some
@@ -107,7 +116,8 @@ public abstract class FileLineImporter extends AbstractImporter {
         List<ImportResult> results = Lists.newArrayList();
         String[] keys = header();
         try {
-            BufferedReader reader = new BufferedReader(new FileReader(FileUtility.expandPath(file)));
+            BufferedReader reader = new BufferedReader(new FileReader(
+                    FileUtility.expandPath(file)));
             String line;
             while ((line = reader.readLine()) != null) {
                 if(keys == null) {

--- a/src/main/java/org/cinchapi/concourse/importer/GeneralCsvImporter.java
+++ b/src/main/java/org/cinchapi/concourse/importer/GeneralCsvImporter.java
@@ -23,6 +23,7 @@
  */
 package org.cinchapi.concourse.importer;
 
+import org.cinchapi.concourse.Concourse;
 import org.cinchapi.concourse.util.Arrays;
 
 import com.google.common.collect.LinkedHashMultimap;
@@ -94,6 +95,17 @@ public class GeneralCsvImporter extends FileLineImporter {
     }
 
     /**
+     * Return a {@link GeneralCsvImporter} that is connected to
+     * {@code concourse}.
+     * 
+     * @param concourse
+     * @return the CsvImport connected to Concourse
+     */
+    public static GeneralCsvImporter withConcourse(Concourse concourse) {
+        return new GeneralCsvImporter(concourse);
+    }
+
+    /**
      * Split a string on a delimiter as long as that delimiter is not wrapped in
      * double quotes.
      * 
@@ -137,6 +149,15 @@ public class GeneralCsvImporter extends FileLineImporter {
     protected GeneralCsvImporter(String host, int port, String username,
             String password, String environment) {
         super(host, port, username, password, environment);
+    }
+
+    /**
+     * Construct a new instance.
+     * 
+     * @param concourse
+     */
+    protected GeneralCsvImporter(Concourse concourse) {
+        super(concourse);
     }
 
     @Override
@@ -218,5 +239,4 @@ public class GeneralCsvImporter extends FileLineImporter {
     private String prepareLine(String line) {
         return line.replaceAll(DELIMITER + " ", DELIMITER);
     }
-
 }

--- a/src/main/java/org/cinchapi/concourse/importer/ImportResult.java
+++ b/src/main/java/org/cinchapi/concourse/importer/ImportResult.java
@@ -129,4 +129,3 @@ public final class ImportResult {
     }
 
 }
-

--- a/src/main/java/org/cinchapi/concourse/importer/cli/AbstractImportCli.java
+++ b/src/main/java/org/cinchapi/concourse/importer/cli/AbstractImportCli.java
@@ -87,6 +87,8 @@ public abstract class AbstractImportCli extends CommandLineInterface {
      */
     protected AbstractImportCli(ImportOptions options, String[] args) {
         super(options, args);
+        setLoginAttemptsRemaining(3);
+        connectToConcourse();
     }
 
     /**

--- a/src/main/java/org/cinchapi/concourse/importer/cli/FileLineImportCli.java
+++ b/src/main/java/org/cinchapi/concourse/importer/cli/FileLineImportCli.java
@@ -57,10 +57,16 @@ public abstract class FileLineImportCli extends AbstractImportCli {
 
     @Override
     protected final void doImport(String file) {
-        Collection<ImportResult> results = importer.importFile(file,
-                ((LineImportOptions) options).resolveKey);
-        System.out.println(MessageFormat.format("Imported {0} lines",
-                results.size()));
+        if(importer != null) {
+            Collection<ImportResult> results = importer.importFile(file,
+                    ((LineImportOptions) options).resolveKey);
+            System.out.println(MessageFormat.format("Imported {0} lines",
+                    results.size()));
+        }
+        else {
+            System.err
+                    .println("Cannot import file:  importer failed to initialize.");
+        }
     }
 
     /**

--- a/src/main/java/org/cinchapi/concourse/importer/cli/GeneralCsvImportCli.java
+++ b/src/main/java/org/cinchapi/concourse/importer/cli/GeneralCsvImportCli.java
@@ -34,16 +34,24 @@ public class GeneralCsvImportCli extends FileLineImportCli {
 
     /**
      * Construct a new instance.
+     * 
      * @param args
      */
     public GeneralCsvImportCli(String... args) {
         super(args);
     }
 
+    /**
+     * {@link GeneralCsvImporter} for Current CLI.
+     */
     @Override
-    protected GeneralCsvImporter importer() {
-        return GeneralCsvImporter.withConnectionInfo(options.host, options.port,
-                options.username, options.password, options.environment);
+    protected final GeneralCsvImporter importer() {
+        if(getConcourse() != null) {
+            return GeneralCsvImporter.withConcourse(getConcourse());
+        }
+        else {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/org/cinchapi/concourse/util/FileUtility.java
+++ b/src/main/java/org/cinchapi/concourse/util/FileUtility.java
@@ -27,31 +27,30 @@ package org.cinchapi.concourse.util;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 
- 
 /**
  * Simple Utility providing tools for working with the file system and paths.
  * 
  * @author hmitchell
  */
 public class FileUtility {
- 
+
     /**
      * The user's home directory, which is used to expand path names with "~"
      * (tilde).
      */
     private static String USER_HOME = System.getProperty("user.home");
- 
+
     /**
      * The working directory from which the current JVM process was launched.
      */
     private static String WORKING_DIRECTORY = System.getProperty("user.dir");
- 
+
     /**
      * The base path that is used to resolve and normalize other relative paths.
      */
     private static Path BASE_PATH = FileSystems.getDefault().getPath(
             WORKING_DIRECTORY);
- 
+
     /**
      * Expand the given {@code path} so that it contains completely normalized
      * components (e.g. ".", "..", and "~" are resolved to the correct absolute
@@ -65,29 +64,32 @@ public class FileUtility {
         path = path.replaceAll("\\$HOME", USER_HOME);
         return BASE_PATH.resolve(path).normalize().toString();
     }
-    
+
     /**
-     * Returns the value of {@link USER_HOME} directory.
-     * @return
+     * Returns the value of {@link #USER_HOME} directory.
+     * 
+     * @return the string value of the user's home directory.
      */
-    public static String getUserHome (){
-    	return USER_HOME;
+    public static String getUserHome() {
+        return USER_HOME;
     }
-    
+
     /**
-     * Returns the value of {@link BASE_PATH} directory.
-     * @return
+     * Returns the value of {@link #BASE_PATH} directory.
+     * 
+     * @return the string value of the base path.
      */
-    public static Path getBasePath(){
-    	return BASE_PATH;
+    public static Path getBasePath() {
+        return BASE_PATH;
     }
-    
+
     /**
-     * Returns the value of {@link WORKING_DIRECTORY} directory.
-     * @return
+     * Returns the value of {@link #WORKING_DIRECTORY} directory.
+     * 
+     * @return the string value of the current working directory.
      */
-    public static String getWorkingDirectory (){
-    	return WORKING_DIRECTORY;
+    public static String getWorkingDirectory() {
+        return WORKING_DIRECTORY;
     }
-    
+
 }

--- a/src/test/java/org/cinchapi/concourse/importer/AbstractImporterTest.java
+++ b/src/test/java/org/cinchapi/concourse/importer/AbstractImporterTest.java
@@ -23,15 +23,11 @@
  */
 package org.cinchapi.concourse.importer;
 
-
 /**
  * Unit tests for {@link AbstractImporter}.
  * 
  * @author jnelson
  */
 public class AbstractImporterTest {
-
-
-  
 
 }

--- a/src/test/java/org/cinchapi/concourse/importer/cli/GeneralCsvImportCliTest.java
+++ b/src/test/java/org/cinchapi/concourse/importer/cli/GeneralCsvImportCliTest.java
@@ -29,54 +29,50 @@ import org.junit.Test;
 
 /**
  * Test cases for {@link GeneralCsvImportCli}.
+ * 
  * @author hmitchell
  *
  */
 public class GeneralCsvImportCliTest extends ClientServerTest {
 
-    @Override
-    protected void afterEachTest() {
-    	importCli = null;
-    }
-
-    @Override
-    protected void beforeEachTest() {
-    	importCli = getImportCli();
+    /**
+     * Test that a {@link GeneralCsvImportCli} command line interface can accept
+     * arguments and import a directory of files without any exceptions.
+     */
+    @Test
+    public void testImportDirectory() throws Exception {
+        getImportCli("admin").run();
     }
 
     /**
-     * Test that a {@link GeneralCsvImportCli} command line interface can accept 
-     * arguments and import a directory of files without any exceptions.
+     * Return a {@link GeneralCsvImportCli} created with default arguments and
+     * {@link pathToData}.
+     * 
+     * @param password
+     * @return the import cli
      */
-	@Test
-	public void testImportDirectory () throws Exception {
-		importCli.run();
-	}
-	
-	/**
-	 * Return a {@link GeneralCsvImportCli} created with default arguments and {@link pathToData}.
-	 * @return
-	 */
-	public GeneralCsvImportCli getImportCli (){
-		 return new GeneralCsvImportCli("--password", "admin", "-p", String.valueOf(server.getClientPort()), "-d", pathToData());
-	}
-	
-	/**
-	 * Path to data to import for test cases.
-	 * @return
-	 */
-	protected String pathToData(){
-		return "bin/../src/test/resources";
-	}
+    public GeneralCsvImportCli getImportCli(String password) {
+        return new GeneralCsvImportCli("--password", password, "-p",
+                String.valueOf(server.getClientPort()), "-d", pathToData());
+    }
+
+    /**
+     * Path to data to import for test cases.
+     * 
+     * @return string value of path
+     */
+    protected String pathToData() {
+        return "bin/../src/test/resources";
+    }
 
     @Override
     protected String getServerVersion() {
         return "0.3.4";
     }
-	
+
     /**
      * {@link GeneralCsvImportCli} used for test cases.
      */
-	protected GeneralCsvImportCli importCli;
+    protected GeneralCsvImportCli importCli;
 
 }

--- a/src/test/java/org/cinchapi/concourse/importer/csv/CollegeImportTest.java
+++ b/src/test/java/org/cinchapi/concourse/importer/csv/CollegeImportTest.java
@@ -23,17 +23,16 @@
  */
 package org.cinchapi.concourse.importer.csv;
 
-
 /**
  * 
  * 
  * @author jnelson
  */
-public class CollegeImportTest extends CsvImportBaseTest{
+public class CollegeImportTest extends CsvImportBaseTest {
 
     @Override
     protected String getImportFile() {
         return "college.csv";
-    }   
+    }
 
 }

--- a/src/test/java/org/cinchapi/concourse/importer/csv/YoutubeImportTest.java
+++ b/src/test/java/org/cinchapi/concourse/importer/csv/YoutubeImportTest.java
@@ -28,7 +28,7 @@ package org.cinchapi.concourse.importer.csv;
  * 
  * @author jnelson
  */
-public class YoutubeImportTest extends CsvImportBaseTest{
+public class YoutubeImportTest extends CsvImportBaseTest {
 
     @Override
     protected String getImportFile() {

--- a/src/test/java/org/cinchapi/concourse/util/FileUtilityTest.java
+++ b/src/test/java/org/cinchapi/concourse/util/FileUtilityTest.java
@@ -30,33 +30,41 @@ import org.junit.Test;
 /**
  * 
  * Unit tests for {@link FileUtility}.
+ * 
  * @author hmitchell
  *
  */
 public class FileUtilityTest {
 
-	/**
-	 * Test that relative paths with be resolved correctly.
-	 */
-	@Test 
+    /**
+     * Test that relative paths with be resolved correctly.
+     */
+    @Test
     public void testExpandPath() {
-		// Test paths starting with "." and containing ".."
+        // Test paths starting with "." and containing ".."
         String path = "./bin/../src/resources";
-        Assert.assertEquals("correct_path_1", FileUtility.getWorkingDirectory() + "/src/resources", FileUtility.expandPath(path));
+        Assert.assertEquals("correct_path_1", FileUtility.getWorkingDirectory()
+                + "/src/resources", FileUtility.expandPath(path));
         // Test paths with multiple ".."
         path = "bin/../bin/../src/resources";
-        Assert.assertEquals("correct_path_2", FileUtility.getWorkingDirectory() + "/src/resources", FileUtility.expandPath(path));
+        Assert.assertEquals("correct_path_2", FileUtility.getWorkingDirectory()
+                + "/src/resources", FileUtility.expandPath(path));
         // Test Unix home tilde.
         path = "~";
-        Assert.assertEquals("correct_path_3", FileUtility.getUserHome(), FileUtility.expandPath(path)); 
+        Assert.assertEquals("correct_path_3", FileUtility.getUserHome(),
+                FileUtility.expandPath(path));
         // Test path with multiple consecutive forward slash.
         path = "./src/resources/////////////////";
-        Assert.assertEquals("correct_path_4", FileUtility.getWorkingDirectory() + "/src/resources", FileUtility.expandPath(path)); 
-        // Test path with multiple consecutive forward slash, followed by multiple "..".        
+        Assert.assertEquals("correct_path_4", FileUtility.getWorkingDirectory()
+                + "/src/resources", FileUtility.expandPath(path));
+        // Test path with multiple consecutive forward slash, followed by
+        // multiple "..".
         path = "./src/resources/////////////////../..";
-        Assert.assertEquals("correct_path_5", FileUtility.getWorkingDirectory(), FileUtility.expandPath(path));
+        Assert.assertEquals("correct_path_5",
+                FileUtility.getWorkingDirectory(), FileUtility.expandPath(path));
         // Test path with $HOME.
         path = "$HOME";
-        Assert.assertEquals("correct_path_6", FileUtility.getUserHome(), FileUtility.expandPath(path)); 
+        Assert.assertEquals("correct_path_6", FileUtility.getUserHome(),
+                FileUtility.expandPath(path));
     }
 }


### PR DESCRIPTION
* AbstractImportCli calls upon framework to connectToConcourse, with 3
login attempts.
* FileLineImportCli checks that the importer has initialized.
* GeneralCsvImportCli passes a Concourse instance to to
GeneralCsvImporter.
* GeneralCsvImporter and FileLineImporter have constructors which take a
Concourse instance.
* GeneralCsvImportCliTest getImportCli method accepts a password.
* Misc. Cinchapi formatter changes throughout.
* Import build script uses the most recent concourse-cli version (1.1.3)
* Includes Cinchapi formatter changes..